### PR TITLE
Add a context manager format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ display.stop()
 
 ```python
 with Display(visible=0, size=(1440, 1880)):
-	# Run browser tests in a headless environment
+    # Run browser tests in a headless environment
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ display.start()
 display.stop()
 ```
 
+### Or as a context manager:
+
+```python
+with Display(visible=0, size=(1440, 1880)):
+	# Run browser tests in a headless environment
+    ...
+```
+
 ## When to use:
 
 If you need to run browser tests on a headless machine (such as a Linux backend), and you can't use a browser's headless mode (such as Chrome's headless mode), then this may help. For example, Chrome does not allow extensions in headless mode, so if you need to run automated tests on a headless Linux machine and you need to use Chrome extensions, then this will let you run those tests using a virtual display.

--- a/sbvirtualdisplay/__version__.py
+++ b/sbvirtualdisplay/__version__.py
@@ -1,2 +1,2 @@
 # sbvirtualdisplay package
-__version__ = "1.1.1"
+__version__ = "1.2.0"

--- a/sbvirtualdisplay/abstractdisplay.py
+++ b/sbvirtualdisplay/abstractdisplay.py
@@ -95,6 +95,15 @@ class AbstractDisplay(EasyProcess):
             self._clear_xauth()
         return self
 
+    def __enter__(self):
+        """Used by the :keyword:`with` statement"""
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        """Used by the :keyword:`with` statement"""
+        self.stop()
+
     def _setup_xauth(self):
         """Set up the Xauthority file & the XAUTHORITY environment variable."""
         handle, filename = tempfile.mkstemp(


### PR DESCRIPTION
## Add a context manager format

Example:

```python
with Display(visible=0, size=(1440, 1880)):
    # Run browser tests in a headless environment
    ...
```

This resolves https://github.com/mdmintz/sbVirtualDisplay/issues/5